### PR TITLE
Add auto connect and password form

### DIFF
--- a/spice.html
+++ b/spice.html
@@ -62,8 +62,8 @@
             document.getElementById('hostname').innerHTML = (host) ;
 
             if (auto === 'true' || auto == '1') {
-            auto = true;
-            connect();
+                auto = true;
+                connect();
             }
 
             function spice_error(e)

--- a/spice.html
+++ b/spice.html
@@ -20,7 +20,7 @@
     Spice Javascript client template.
     Refer to main.js for more detailed information
    --------------------------------------------------
-
+   S.Fairweather added addition functions to allow being called from external source and form for password. 
 -->
 
 <!doctype html>
@@ -46,18 +46,41 @@
 
         <script type="module" crossorigin="anonymous">
             import * as SpiceHtml5 from './src/main.js';
+            window.connect = connect;
 
             var host = null, port = null;
             var sc;
 
+            var auto = urlParams.get('autoconnect') ;
+            var host = urlParams.get("host") ;
+            var port = urlParams.get("port") ;
+            var password = urlParams.get("password") ;
+               
+            document.getElementById("host").value = host ;
+            document.getElementById("port").value = port;
+            document.getElementById("password").value = password;
+            document.getElementById('hostname').innerHTML = (host) ;
+
+            if (auto === 'true' || auto == '1') {
+            auto = true;
+            connect();
+            }
+
             function spice_error(e)
             {
                 disconnect();
+                if (e !== undefined && e.message === "Permission denied.") {
+                    document.getElementById("passwordForm").style.display = "block";  
+                } 
             }
 
             function connect()
             {
                 var host, port, password, scheme = "ws://", uri;
+
+                if (window.location.protocol == 'https:') {
+                    scheme = "wss://";
+                }
 
                 host = document.getElementById("host").value;
                 port = document.getElementById("port").value;
@@ -175,7 +198,23 @@
             <div id="spice-screen" class="spice-screen"></div>
         </div>
 
+        <div class="form-popup" id="passwordForm">
+            <form action="/action_page.php" class="form-container">
+              <h3>Spice requires a password.</h3>
+
+              <input type="password" autocomplete="off" placeholder="Enter Password" id="psw" name="psw" required>
+          
+              <button type="button" class="btn cancel" onclick="connectpsw()">Connect</button>
+            </form>
+        </div>
+
         <script>
+            function connectpsw() {
+                document.getElementById("password").value = document.getElementById("psw").value;   
+                document.getElementById("passwordForm").style.display = "none"; 
+                connect() ;   
+            }
+
             function show_debug_Logs() {
                 var content = document.getElementById('message-div')
                 if (content.style.display === 'block') {
@@ -201,7 +240,7 @@
             }
 
             document.getElementById('debugLogs').addEventListener('click', function() { show_debug_Logs(); });
-            display_hostname()
+            
         </script>
     </body>
 </html>


### PR DESCRIPTION
Allows auto connect, host and port to be passed in URL, 

spice.html?v=x&autoconnect=true&host=x.y.net&port=/wsproxy/5900/

Password form used if host has a password set.
![image](https://user-images.githubusercontent.com/39065407/184526958-c1778217-fa67-4a0b-97a8-907a91a40fd0.png)

And for my use case I have added/amended the following lines not included in the PR

`        <title>Spice Javascript client</title>
        <base href="spice/">
        <link rel="stylesheet" type="text/css" href="./spice.css" />`

I know there is spice_auto but I was looking to be able to have a single version that could be used for either requirements.

Thank you for taking the time to review and let me know if you want me to raise in another location.

I have seen the TODO, but is there a formal published development road map?